### PR TITLE
Revert "Fix pre-commit version constraint for Python 3.8-3.9 compatibility"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ black>=23.0.0
 mypy>=1.0.0
 flake8>=6.0.0
 isort>=5.12.0
-pre-commit>=3.5.0,<4.0.0
+pre-commit==4.3.0
 
 # Documentation
 sphinx>=7.0.0


### PR DESCRIPTION
Reverts Refactron-ai/Refactron_lib#59