### PR TITLE
perf: Share SentenceTransformer between RAGIndexer and ContextRetriever

### DIFF
--- a/refactron/rag/indexer.py
+++ b/refactron/rag/indexer.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
+from functools import lru_cache
 
 try:
     import chromadb
@@ -18,6 +19,16 @@ except ImportError:
     Settings = None
     SentenceTransformer = None
     CHROMA_AVAILABLE = False
+
+@lru_cache(maxsize=2)
+def get_sentence_transformer(model_name: str) -> Any:
+    """Module-level LRU cache for SentenceTransformer to avoid duplicate memory allocation."""
+    if not SentenceTransformer:
+        raise RuntimeError(
+            "sentence-transformers is not available. "
+            "Install with: pip install sentence-transformers"
+        )
+    return SentenceTransformer(model_name)
 
 from refactron.rag.chunker import CodeChunk
 from refactron.rag.parser import CodeParser
@@ -46,7 +57,7 @@ class RAGIndexer:
     def __init__(
         self,
         workspace_path: Path,
-        embedding_model: str = "all-MiniLM-L6-v2",
+        embedding_model: Any = "all-MiniLM-L6-v2",
         collection_name: str = "code_chunks",
         llm_client: Optional[GroqClient] = None,
     ):
@@ -74,8 +85,12 @@ class RAGIndexer:
         self.llm_client = llm_client
 
         # Initialize embedding model
-        self.embedding_model_name = embedding_model
-        self.embedding_model = SentenceTransformer(embedding_model)
+        if isinstance(embedding_model, str):
+            self.embedding_model_name = embedding_model
+            self.embedding_model = get_sentence_transformer(embedding_model)
+        else:
+            self.embedding_model_name = "custom_model"
+            self.embedding_model = embedding_model
 
         # Initialize ChromaDB
         self.client = chromadb.PersistentClient(

--- a/refactron/rag/retriever.py
+++ b/refactron/rag/retriever.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Any
+
+from refactron.rag.indexer import get_sentence_transformer
 
 try:
     import chromadb
@@ -38,7 +40,7 @@ class ContextRetriever:
     def __init__(
         self,
         workspace_path: Path,
-        embedding_model: str = "all-MiniLM-L6-v2",
+        embedding_model: Any = "all-MiniLM-L6-v2",
         collection_name: str = "code_chunks",
     ):
         """Initialize the context retriever.
@@ -58,7 +60,10 @@ class ContextRetriever:
         self.index_path = self.workspace_path / ".rag"
 
         # Initialize embedding model
-        self.embedding_model = SentenceTransformer(embedding_model)
+        if isinstance(embedding_model, str):
+            self.embedding_model = get_sentence_transformer(embedding_model)
+        else:
+            self.embedding_model = embedding_model
 
         # Initialize ChromaDB client
         self.client = chromadb.PersistentClient(


### PR DESCRIPTION

solve #151 
The recent updates significantly optimize the memory footprint and startup latency across the entire retrieval-augmented generation (RAG) subsystem. Previously, both the RAGIndexer and ContextRetriever classes independently initialized separate instances of the intensive SentenceTransformer model, causing redundant memory allocation and delayed workload execution—especially noticeable in workflows that sequentially index and then immediately query. We resolved this by implementing a fast, module-level LRU caching factory that centrally manages the heavy machine learning weights. By updating the constructors to accept generic types, both classes now natively query this cache when provided with a model string, safely sharing a singular process-wide model instance. Additionally, we enabled dynamic dependency injection, allowing advanced users to directly pass pre-warmed model objects into either class entirely bypassing string lookups, all while strictly preserving backward compatibility with the existing public interface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced RAG system to accept embedding models as either string identifiers or pre-constructed objects.
  * Improved memory efficiency through embedding model reuse and caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->