### PR TITLE
perf: Reuse CodeChunker in RAGIndexer._index_file

### DIFF
--- a/refactron/rag/indexer.py
+++ b/refactron/rag/indexer.py
@@ -89,6 +89,8 @@ class RAGIndexer:
         )
 
         self.parser = CodeParser()
+        from refactron.rag.chunker import CodeChunker
+        self.chunker = CodeChunker(self.parser)
 
     def index_repository(
         self, repo_path: Optional[Path] = None, summarize: bool = False
@@ -171,11 +173,8 @@ class RAGIndexer:
         Returns:
             List of code chunks that were indexed
         """
-        from refactron.rag.chunker import CodeChunker
-
         # Chunk the file (parser is called inside chunker)
-        chunker = CodeChunker(self.parser)
-        chunks = chunker.chunk_file(file_path)
+        chunks = self.chunker.chunk_file(file_path)
 
         if summarize and self.llm_client:
             for chunk in chunks:


### PR DESCRIPTION
solve #152 
The recent optimization targets a structural inefficiency found during large-scale repository indexing, where a fresh instance of the CodeChunker class was needlessly being rebuilt for every single file processed by the system. Since the chunker operates generally statelessly—aside from initially binding to the underlying CodeParser—we completely eliminated this deep-loop overhead by hoisting the instantiation out of the _index_file method and statically caching it just once during the overarching RAGIndexer initialization. Now, the RAGIndexer sustainably reuses its internal self.chunker mechanism to dissect files consecutively across the entire directory crawl. This dramatically reduces garbage collection workload and redundant memory reallocation per file iteration, streamlining overall traversal durations while remaining entirely functionally identical for all existing tests and processes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the file indexing process for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->