### PR TITLE
Fix/testsuitegate pytest interpreter cwd

### DIFF
--- a/refactron/verification/checks/test_gate.py
+++ b/refactron/verification/checks/test_gate.py
@@ -20,6 +20,8 @@ class TestSuiteGate(BaseCheck):
 
     def __init__(self, project_root: Optional[Path] = None):
         self.project_root = project_root
+        self._test_file_cache: Optional[Dict[str, List[Path]]] = None
+        self._all_test_files: Optional[List[Path]] = None
 
     def verify(self, original: str, transformed: str, file_path: Path) -> CheckResult:
         start = time.monotonic()
@@ -110,11 +112,27 @@ class TestSuiteGate(BaseCheck):
         module_name = file_path.stem
         search_root = self.project_root or file_path.parent
 
+        if self._test_file_cache is None:
+            self._test_file_cache = {}
+            self._all_test_files = []
+            
+            test_dirs = [d for d in [search_root / "tests", search_root / "test"] if d.is_dir()]
+            search_dirs = test_dirs if test_dirs else [search_root]
+            excluded_dirs = {".git", ".rag", "__pycache__", "venv", ".venv", "env", "node_modules"}
+            
+            for root_dir in search_dirs:
+                for py_file in root_dir.rglob("*.py"):
+                    if any(excluded in py_file.parts for excluded in excluded_dirs):
+                        continue
+                    name = py_file.name
+                    if name.startswith("test_") or name.endswith("_test.py"):
+                        self._all_test_files.append(py_file)
+
+        if module_name in self._test_file_cache:
+            return self._test_file_cache[module_name]
+
         test_files: List[Path] = []
-        for py_file in search_root.rglob("*.py"):
-            name = py_file.name
-            if not (name.startswith("test_") or name.endswith("_test.py")):
-                continue
+        for py_file in self._all_test_files:  # type: ignore
             if py_file == file_path:
                 continue
             try:
@@ -123,6 +141,8 @@ class TestSuiteGate(BaseCheck):
                     test_files.append(py_file)
             except Exception:
                 continue
+                
+        self._test_file_cache[module_name] = test_files
         return test_files
 
     @staticmethod

--- a/refactron/verification/checks/test_gate.py
+++ b/refactron/verification/checks/test_gate.py
@@ -4,6 +4,7 @@ import ast
 import os
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -56,16 +57,30 @@ class TestSuiteGate(BaseCheck):
             # Delete .pyc cache
             self._clear_pycache(file_path)
 
-            # Run pytest
-            cmd = ["python3", "-m", "pytest", "-x", "-q"]
+            # Run pytest from the project root with the host interpreter so
+            # the repo's pyproject.toml / pytest.ini / conftest.py are picked
+            # up and the same venv as the host process is used.
+            run_cwd = (self.project_root or file_path.parent).resolve()
+
+            # Make the project root importable for edge cases where the layout
+            # relies on PYTHONPATH rather than an installed package.
+            env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+            existing_pythonpath = env.get("PYTHONPATH", "")
+            env["PYTHONPATH"] = (
+                os.pathsep.join([str(run_cwd), existing_pythonpath])
+                if existing_pythonpath
+                else str(run_cwd)
+            )
+
+            cmd = [sys.executable, "-m", "pytest", "-x", "-q"]
             cmd += [str(f) for f in test_files]
             result = subprocess.run(
                 cmd,
                 timeout=45,
                 capture_output=True,
                 text=True,
-                env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
-                cwd=str(file_path.parent),
+                env=env,
+                cwd=str(run_cwd),
             )
 
             elapsed = int((time.monotonic() - start) * 1000)
@@ -115,11 +130,11 @@ class TestSuiteGate(BaseCheck):
         if self._test_file_cache is None:
             self._test_file_cache = {}
             self._all_test_files = []
-            
+
             test_dirs = [d for d in [search_root / "tests", search_root / "test"] if d.is_dir()]
             search_dirs = test_dirs if test_dirs else [search_root]
             excluded_dirs = {".git", ".rag", "__pycache__", "venv", ".venv", "env", "node_modules"}
-            
+
             for root_dir in search_dirs:
                 for py_file in root_dir.rglob("*.py"):
                     if any(excluded in py_file.parts for excluded in excluded_dirs):
@@ -141,7 +156,7 @@ class TestSuiteGate(BaseCheck):
                     test_files.append(py_file)
             except Exception:
                 continue
-                
+
         self._test_file_cache[module_name] = test_files
         return test_files
 

--- a/tests/test_test_gate.py
+++ b/tests/test_test_gate.py
@@ -1,9 +1,12 @@
 """Unit tests for TestSuiteGate (Check 3)."""
 
+import os
+import sys
 from pathlib import Path
 
 import pytest
 
+from refactron.verification.checks import test_gate as test_gate_module
 from refactron.verification.checks.test_gate import TestSuiteGate
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -71,3 +74,61 @@ class TestTestSuiteGate:
         original = file_path.read_text(encoding="utf-8")
         cr = gate.verify(original, original, file_path)
         assert cr.confidence == 0.9
+
+
+class TestPytestInvocation:
+    """The pytest subprocess must use the host interpreter and project root."""
+
+    def _capture_run(self, monkeypatch):
+        """Patch subprocess.run to capture its arguments without running pytest."""
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["cwd"] = kwargs.get("cwd")
+            captured["env"] = kwargs.get("env")
+
+            class _Completed:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _Completed()
+
+        monkeypatch.setattr(test_gate_module.subprocess, "run", fake_run)
+        return captured
+
+    def test_uses_host_interpreter(self, monkeypatch):
+        """pytest must run via sys.executable, not a hard-coded python3."""
+        captured = self._capture_run(monkeypatch)
+        gate = TestSuiteGate(project_root=FIXTURES_DIR)
+        file_path = FIXTURES_DIR / "fixture_test_break.py"
+        original = file_path.read_text(encoding="utf-8")
+
+        gate.verify(original, original, file_path)
+
+        assert captured["cmd"][0] == sys.executable
+        assert captured["cmd"][1:4] == ["-m", "pytest", "-x"]
+
+    def test_cwd_is_resolved_project_root(self, monkeypatch):
+        """pytest must run from the resolved project root, not file_path.parent."""
+        captured = self._capture_run(monkeypatch)
+        gate = TestSuiteGate(project_root=FIXTURES_DIR)
+        file_path = FIXTURES_DIR / "fixture_test_break.py"
+        original = file_path.read_text(encoding="utf-8")
+
+        gate.verify(original, original, file_path)
+
+        assert captured["cwd"] == str(FIXTURES_DIR.resolve())
+
+    def test_project_root_added_to_pythonpath(self, monkeypatch):
+        """The project root must be present on PYTHONPATH for the subprocess."""
+        captured = self._capture_run(monkeypatch)
+        gate = TestSuiteGate(project_root=FIXTURES_DIR)
+        file_path = FIXTURES_DIR / "fixture_test_break.py"
+        original = file_path.read_text(encoding="utf-8")
+
+        gate.verify(original, original, file_path)
+
+        pythonpath = captured["env"]["PYTHONPATH"].split(os.pathsep)
+        assert str(FIXTURES_DIR.resolve()) in pythonpath


### PR DESCRIPTION
solve #188 
 TestSuiteGate.verify ran its pytest subprocess with a hard-coded python3 interpreter and cwd set to file_path.parent. When the edited file is nested inside the project, running from the file's own    
  directory means pytest does not see the repository's pyproject.toml, pytest.ini, or conftest.py, so configuration-dependent tests either fail for the wrong reasons or are not discovered at all.
  Hard-coding python3 also risks running under a different interpreter or virtual environment than the host process, which leads to false positives in the verification gate and mismatches between local
  and CI behavior.

  This change makes the subprocess run in the correct context. pytest is now invoked via sys.executable so it always uses the same interpreter and venv as the host process. The subprocess cwd is set to 
  the resolved project root (project_root when known, otherwise the file's directory), so pytest discovers the repo's configuration and conftest.py regardless of how deeply the edited file is nested. As
   a safety net for project layouts that rely on PYTHONPATH rather than an installed package, the resolved project root is prepended to PYTHONPATH for the subprocess while preserving any existing value.

  The change is covered by three new tests in tests/test_test_gate.py that patch subprocess.run to assert the command runs via sys.executable, that cwd is the resolved project root rather than
  file_path.parent, and that the project root is present on the subprocess PYTHONPATH. All ten tests in the file pass, and the changed files are clean under black, isort, and flake8.